### PR TITLE
Apply glassmorphism to dropdown menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -375,44 +375,52 @@ footer {
     align-items: center;
   }
 
-  /* Mobile overlay menu */
+  /* Mobile dropdown (glassmorphism) */
   #nav-menu {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transform: translateY(-100%);
-    transition: transform 0.3s ease;
-    background: rgba(10, 0, 40, 0.9);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
+    top: 70px;
+    left: 12px;
+    right: 12px;
+    width: auto;
+    height: auto;
+    max-height: 65vh;
+    overflow-y: auto;
+    display: block;
+    transform: translateY(-12px);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform 0.25s ease, opacity 0.25s ease;
+    background: rgba(20, 0, 40, 0.55);
+    backdrop-filter: blur(12px) saturate(120%);
+    -webkit-backdrop-filter: blur(12px) saturate(120%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 16px;
+    padding: 12px 16px;
     z-index: 80;
     margin-top: 0; /* override previous spacing */
   }
 
   #nav-menu ul {
     flex-direction: column;
-    gap: 1.2rem;
-    align-items: center;
+    gap: 0.6rem;
+    align-items: stretch;
   }
 
   .menu-toggle {
     display: block;
   }
 
-  /* When active, slide the overlay down */
+  /* When active, show the dropdown */
   #nav-menu.active {
     transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
   }
 
   /* Prevent background scroll when menu is open */
   body.menu-open {
     overflow: hidden;
-    height: 100vh;
+    touch-action: none;
   }
 
   .hero-text h1 {


### PR DESCRIPTION
Refactor mobile menu to be a glassmorphism dropdown instead of a full-screen overlay, while preventing background scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-2818ae63-58a0-490a-971a-6d8c3d4d1da9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2818ae63-58a0-490a-971a-6d8c3d4d1da9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

